### PR TITLE
Portable controllers

### DIFF
--- a/core/lib/Builddesc
+++ b/core/lib/Builddesc
@@ -15,6 +15,9 @@ LIB(sebase-core
 	srcs::linux[
 		controller-epoll.c
 	]
+	srcs::!linux[
+		controller-kqueue.c
+	]
 	incprefix[sbp]
 	includes[
 		controller.h create_socket.h daemon.h etcdclient.h fd_pool.h

--- a/core/lib/Builddesc
+++ b/core/lib/Builddesc
@@ -9,19 +9,17 @@ LIB(sebase-core
 		fd_pool.c fd_pool_url_scheme.gperf fd_pool_sd.c http_fd_pool.c
 		log_event.c parse_query_string.c platform_app.c
 		sd_command.gperf sd_queue.c sd_registry.c
+		controller-log.c controller-stats.c controller.c
 	]
 	# Controllers currently require epoll and eventfd.
 	srcs::linux[
-		controller-log.c controller-stats.c controller.c
+		controller-epoll.c
 	]
 	incprefix[sbp]
 	includes[
-		create_socket.h daemon.h etcdclient.h fd_pool.h
+		controller.h create_socket.h daemon.h etcdclient.h fd_pool.h
 		fd_pool_sd.h http_fd_pool.h log_event.h parse_query_string.h
 		platform_app.h sd_queue.h sd_registry.h
-	]
-	includes::linux[
-		controller.h
 	]
 	specialsrcs[
 		gperf_switch:controller.c:ctrl_header.gperf

--- a/core/lib/controller-epoll.c
+++ b/core/lib/controller-epoll.c
@@ -1,0 +1,53 @@
+#include "controller-events.h"
+
+#include <sys/epoll.h>
+
+#define CONTROLLER_EPOLL_TIMEOUT_MS 2000
+#define CONTROLLER_NUM_FDS 64
+
+int
+event_e_init(union ctrl_event_e *e) {
+	e->epollfd = epoll_create(CONTROLLER_NUM_FDS);
+	return 0;
+}
+
+int
+event_e_close(union ctrl_event_e *e) {
+	close(e->epollfd);
+	e->epollfd = -1;
+	return 0;
+}
+
+int
+event_e_add(union ctrl_event_e *e, struct event_handler *event_handler, int fd) {
+	struct epoll_event event;
+	event.events = EPOLLIN|EPOLLHUP;
+	event.data.ptr = event_handler;
+	return epoll_ctl(e->epollfd, EPOLL_CTL_ADD, fd, &event);
+}
+
+int
+event_e_remove(union ctrl_event_e *e, int fd) {
+	struct epoll_event event;
+	return epoll_ctl(e->epollfd, EPOLL_CTL_DEL, fd, &event);
+}
+
+int
+event_e_triggered(union ctrl_event_e *e, int fd) {
+	return event_e_remove(e, fd);
+}
+
+int
+event_e_handle(union ctrl_event_e *e, struct ctrl *ctrl) {
+	struct epoll_event events[CONTROLLER_NUM_FDS];
+	int nfds;
+	/* Wake up every x to handle quit */
+	if ((nfds = epoll_wait(e->epollfd, events, CONTROLLER_NUM_FDS, CONTROLLER_EPOLL_TIMEOUT_MS)) < 0)
+		return -1;
+
+	for (int i = 0; i < nfds; i++) {
+		struct event_handler *event_handler = events[i].data.ptr;
+		event_handler->cb(event_handler, ctrl);
+	}
+	return 0;
+}

--- a/core/lib/controller-epoll.c
+++ b/core/lib/controller-epoll.c
@@ -19,7 +19,7 @@ event_e_close(union ctrl_event_e *e) {
 }
 
 int
-event_e_add(union ctrl_event_e *e, struct event_handler *event_handler, int fd) {
+event_e_add(union ctrl_event_e *e, struct event_handler *event_handler, int fd, bool oneshot) {
 	struct epoll_event event;
 	event.events = EPOLLIN|EPOLLHUP;
 	event.data.ptr = event_handler;
@@ -33,7 +33,7 @@ event_e_remove(union ctrl_event_e *e, int fd) {
 }
 
 int
-event_e_triggered(union ctrl_event_e *e, int fd) {
+event_e_oneshot_triggered(union ctrl_event_e *e, int fd) {
 	return event_e_remove(e, fd);
 }
 

--- a/core/lib/controller-events.h
+++ b/core/lib/controller-events.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "sbp/queue.h"
+
+struct ctrl;
+
+struct event_handler {
+	void (*cb)(struct event_handler *, struct ctrl *);
+	int fd;
+	struct tls *tls;
+	TAILQ_ENTRY(event_handler) event_entry;
+};
+
+union ctrl_event_e {
+	int epollfd;
+};
+
+int event_e_init(union ctrl_event_e *e);
+int event_e_close(union ctrl_event_e *e);
+
+int event_e_add(union ctrl_event_e *e, struct event_handler *event_handler, int fd);
+int event_e_remove(union ctrl_event_e *e, int fd);
+int event_e_triggered(union ctrl_event_e *e, int fd);
+
+int event_e_handle(union ctrl_event_e *e, struct ctrl *ctrl);

--- a/core/lib/controller-events.h
+++ b/core/lib/controller-events.h
@@ -2,6 +2,8 @@
 
 #include "sbp/queue.h"
 
+#include <stdbool.h>
+
 struct ctrl;
 
 struct event_handler {
@@ -13,13 +15,14 @@ struct event_handler {
 
 union ctrl_event_e {
 	int epollfd;
+	int kqfd;
 };
 
 int event_e_init(union ctrl_event_e *e);
 int event_e_close(union ctrl_event_e *e);
 
-int event_e_add(union ctrl_event_e *e, struct event_handler *event_handler, int fd);
+int event_e_add(union ctrl_event_e *e, struct event_handler *event_handler, int fd, bool oneshot);
 int event_e_remove(union ctrl_event_e *e, int fd);
-int event_e_triggered(union ctrl_event_e *e, int fd);
+int event_e_oneshot_triggered(union ctrl_event_e *e, int fd);
 
 int event_e_handle(union ctrl_event_e *e, struct ctrl *ctrl);

--- a/core/lib/controller-kqueue.c
+++ b/core/lib/controller-kqueue.c
@@ -1,0 +1,61 @@
+#include "controller-events.h"
+
+#include <sys/types.h>
+#include <sys/event.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#define CONTROLLER_KQ_TIMEOUT_S 2
+#define CONTROLLER_NUM_FDS 64
+
+int
+event_e_init(union ctrl_event_e *e) {
+	e->kqfd = kqueue();
+	return 0;
+}
+
+int
+event_e_close(union ctrl_event_e *e) {
+	close(e->kqfd);
+	e->kqfd = -1;
+	return 0;
+}
+
+int
+event_e_add(union ctrl_event_e *e, struct event_handler *event_handler, int fd, bool oneshot) {
+	struct kevent event;
+	int flags = EV_ADD | (oneshot ? EV_ONESHOT : 0);
+	EV_SET(&event, fd, EVFILT_READ, flags, 0, 0, event_handler);
+	return kevent(e->kqfd, &event, 1, NULL, 0, NULL);
+}
+
+int
+event_e_remove(union ctrl_event_e *e, int fd) {
+	struct kevent event;
+	EV_SET(&event, fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);
+	return kevent(e->kqfd, &event, 1, NULL, 0, NULL);
+}
+
+int
+event_e_oneshot_triggered(union ctrl_event_e *e, int fd) {
+	// Noop because of EV_ONESHOT.
+	return 0;
+}
+
+int
+event_e_handle(union ctrl_event_e *e, struct ctrl *ctrl) {
+	struct kevent events[CONTROLLER_NUM_FDS];
+	int nfds;
+	struct timespec to = { .tv_sec = CONTROLLER_KQ_TIMEOUT_S };
+
+	/* Wake up every x to handle quit */
+	nfds = kevent(e->kqfd, NULL, 0, events, CONTROLLER_NUM_FDS, &to);
+	if (nfds < 0)
+		return -1;
+
+	for (int i = 0; i < nfds; i++) {
+		struct event_handler *event_handler = events[i].udata;
+		event_handler->cb(event_handler, ctrl);
+	}
+	return 0;
+}

--- a/core/lib/controller-log.c
+++ b/core/lib/controller-log.c
@@ -1,6 +1,7 @@
 // Copyright 2018 Schibsted
 
 #include <stdio.h>
+#include <string.h>
 
 #include "sbp/bconf.h"
 #include <controller.h>

--- a/core/test/Builddesc
+++ b/core/test/Builddesc
@@ -3,8 +3,6 @@
 COMPONENT([
 	fd_pool
 	sapp
-]
-::linux[
 	controller
 	http-fd-pool
 ])

--- a/core/test/controller/main.c
+++ b/core/test/controller/main.c
@@ -8,6 +8,7 @@
 #include "sbp/logging.h"
 #include <inttypes.h>
 #include <netdb.h>
+#include <string.h>
 #include <unistd.h>
 #include <time.h>
 
@@ -206,7 +207,9 @@ dump_qs_cb(struct ctrl_req *cr, struct stringmap *qs, void *data) {
 
 static int
 run(void) {
+#ifndef __APPLE__
 	setproctitle("initialize");
+#endif
 
 	struct ctrl_handler handlers[] = {
 		CONTROLLER_DEFAULT_HANDLERS,
@@ -327,7 +330,9 @@ run(void) {
 		nanosleep(&(const struct timespec){ .tv_nsec = 250 * 1000 * 1000 }, NULL);
 
 	startup_ready("regress_controller");
+#ifndef __APPLE__
 	setproctitle("running");
+#endif
 
 	semaphore_wait(&state.stop_sem);
 	ctrl_quit_stage_two(state.ctrl);

--- a/core/test/controller/regress-runner.mk
+++ b/core/test/controller/regress-runner.mk
@@ -1,7 +1,5 @@
 # Copyright 2018 Schibsted
 
-# Controllers only work on linux for now, needs epoll and eventfd.
-ifeq ($(findstring linux,${MAKE_HOST}),linux)
 print-tests:
 	@echo DEPEND: ${REGRESS_DEPEND}
 	@echo TEST: ${REGRESS_TARGETS}
@@ -47,7 +45,7 @@ REGRESS_TARGETS+=post-ctrl-only_get
 
 
 TESTOUT=${TESTDIR}/test.out
-PYTHON=python
+PYTHON=$$(command -v python || command -v python3)
 
 cleanup:
 	rm -f .template.out .testport
@@ -78,6 +76,3 @@ pctrl-%:
 
 enforce-min-nthreads:
 	curl -s http://127.0.0.1:$$(cat .testport)/stats | ${PYTHON} $@.py
-else
-print-tests:
-endif

--- a/core/test/http-fd-pool/gencert.sh
+++ b/core/test/http-fd-pool/gencert.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Schibsted
 #exec 2>/dev/null
 openssl req -config <(printf "

--- a/core/test/http-fd-pool/regress-runner.mk
+++ b/core/test/http-fd-pool/regress-runner.mk
@@ -1,12 +1,7 @@
 # Copyright 2018 Schibsted
 
-# Controllers only work on linux for now, needs epoll and eventfd.
-ifeq ($(findstring linux,${MAKE_HOST}),linux)
 print-tests:
 	@echo TEST: test
 
 test:
 	regress-http-fd-pool
-else
-print-tests:
-endif

--- a/util/test/Builddesc
+++ b/util/test/Builddesc
@@ -2,14 +2,12 @@
 
 COMPONENT([
 	buf_string
+	http
 	stat_messages
 	string-functions
 	timer
 	unicode
 	xerr
-]
-::linux[
-	http
 ])
 
 PROG(sbalance_test

--- a/util/test/http/regress-runner.mk
+++ b/util/test/http/regress-runner.mk
@@ -1,7 +1,5 @@
 # Copyright 2018 Schibsted
 
-# Controllers only work on linux for now, needs epoll and eventfd.
-ifeq ($(findstring linux,${MAKE_HOST}),linux)
 print-tests:
 	@echo DEPEND: start-server
 	@echo TEST: get_discard get_keep post post_silly_headers
@@ -69,6 +67,3 @@ copy:
 https_get_discard:
 	bash -c 'export REGRESS_HTTPS_PORT=$$((49152 + $$RANDOM % 16384)) ; ${CMD_PREFIX} testhttp get_discard https://localhost:$$REGRESS_HTTPS_PORT/stats > .test.out'
 	match .test.out $@.out
-else
-print-tests:
-endif


### PR DESCRIPTION
This makes controllers work on OpenBSD and macOS. Like mentioned in the first commit, since it's quite little code to specialize for epoll/kqueue I decided to do that instead of adding a third party dependency.
