### PR TITLE
Check go fd pool connections for hangup before reusing.

### DIFF
--- a/core/pkg/fd_pool/common_test.go
+++ b/core/pkg/fd_pool/common_test.go
@@ -30,6 +30,7 @@ func readwrite(tb testing.TB, pool FdPool, service string) {
 	if err != nil {
 		tb.Fatal(err)
 	}
+	defer conn.Close()
 
 	_, err = io.WriteString(conn, "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
 	if err != nil {

--- a/core/pkg/fd_pool/common_test.go
+++ b/core/pkg/fd_pool/common_test.go
@@ -15,6 +15,8 @@ var l net.Listener
 var port int
 
 func init() {
+	DebugLog = defaultLogger(true)
+
 	l, err := net.Listen("tcp", ":0")
 	if err != nil {
 		log.Fatal(err)

--- a/core/pkg/fd_pool/cpool.go
+++ b/core/pkg/fd_pool/cpool.go
@@ -28,6 +28,8 @@ import "C"
 
 // Fd pool wrapping a C pool. Normally you should prefer to use the Go version
 // instead. CPool usually ignores any context.Context arguments given to it.
+//
+// CPool connections do not currently support deadlines.
 type CPool struct {
 	pool          *C.struct_fd_pool
 	dialDomain    *C.char

--- a/core/pkg/fd_pool/gopool.go
+++ b/core/pkg/fd_pool/gopool.go
@@ -542,6 +542,8 @@ func (c *conn) get(ctx context.Context, status sbalance.ConnStatus) (NetConn, er
 			if err == nil {
 				err = &ErrNoServiceNodes{c.service, strings.Join(c.portKey, ",")}
 			}
+			c.Conn = nil
+			c.closed = 1
 			return nil, err
 		}
 		c.srv.sblock.RUnlock()

--- a/core/pkg/fd_pool/gopool_test.go
+++ b/core/pkg/fd_pool/gopool_test.go
@@ -82,6 +82,7 @@ func TestUpdateHosts(t *testing.T) {
 	testLastClosed = nil
 	nc := c.(*conn).Conn
 	c.Put()
+	c.Close() // Test that close after put is no-op.
 	if testLastClosed != nil {
 		t.Fatal("Connection closed by Put")
 	}
@@ -168,6 +169,13 @@ func TestNext(t *testing.T) {
 	n2 := c.(*conn).srvnode
 	if n1 == n2 {
 		t.Error("Got the same node after next.")
+	}
+	err = c.Next(context.TODO(), sbalance.Fail)
+	if err == nil {
+		t.Error("Expected next to fail but it didn't.")
+	}
+	if c.(*conn).Conn != nil {
+		t.Error("Expected conn.Conn to be nil after Next failed.")
 	}
 }
 

--- a/core/pkg/fd_pool/gopool_test.go
+++ b/core/pkg/fd_pool/gopool_test.go
@@ -5,6 +5,7 @@ package fd_pool
 import (
 	"context"
 	"fmt"
+	"log"
 	"net"
 	"runtime"
 	"strconv"
@@ -29,6 +30,7 @@ func TestConf(t *testing.T) {
 
 func TestGoSingle(t *testing.T) {
 	pool := NewGoPool(nil)
+	defer pool.Close()
 	err := pool.AddSingle(context.TODO(), "test", "tcp", fmt.Sprintf("localhost:%d", port), 1, 1*time.Second)
 	if err != nil {
 		t.Fatal("addsingle", err)
@@ -59,6 +61,7 @@ func testDial(ctx context.Context, nw, addr string) (net.Conn, error) {
 
 func TestUpdateHosts(t *testing.T) {
 	pool := NewGoPool(nil)
+	defer pool.Close()
 	pool.AddSingle(context.TODO(), "test", "tcp", fmt.Sprintf("127.0.0.1:%d", port), DefaultRetries, 1*time.Second)
 	pool.SetDialFunc("test", testDial)
 
@@ -140,6 +143,7 @@ func TestUpdateHosts(t *testing.T) {
 
 func TestNext(t *testing.T) {
 	pool := NewGoPool(nil)
+	defer pool.Close()
 	pool.AddSingle(context.TODO(), "test", "tcp", fmt.Sprintf("127.0.0.1:%d", port), DefaultRetries, 1*time.Second)
 	pool.AddSingle(context.TODO(), "test", "tcp", fmt.Sprintf("[::1]:%d", port), DefaultRetries, 1*time.Second)
 
@@ -165,4 +169,61 @@ func TestNext(t *testing.T) {
 	if n1 == n2 {
 		t.Error("Got the same node after next.")
 	}
+}
+
+func TestReused(t *testing.T) {
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer ln.Close()
+	lconch := make(chan net.Conn)
+	go func() {
+		defer close(lconch)
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			lconch <- conn
+		}
+	}()
+
+	// Setup
+	port = ln.Addr().(*net.TCPAddr).Port
+	pool := NewGoPool(nil)
+	defer pool.Close()
+	pool.AddSingle(context.TODO(), "test", "tcp", fmt.Sprintf("127.0.0.1:%d", port), DefaultRetries, 1*time.Second)
+	c, err := pool.NewConn(context.TODO(), "test", "port", "")
+	if err != nil {
+		t.Fatal("NewConn", err)
+	}
+
+	// Check that put + newconn gets the same connection back.
+	conn1 := c.(*conn).Conn
+	c.Put()
+	c, err = pool.NewConn(context.TODO(), "test", "port", "")
+	if err != nil {
+		t.Fatal("NewConn", err)
+	}
+	if conn1 != c.(*conn).Conn {
+		t.Error("Connection wasn't reused after Put.")
+	}
+
+	// Check again but close from server-side. NewConn should now return a new connection.
+	c.Put()
+	lconn := <-lconch
+	lconn.Close()
+	c, err = pool.NewConn(context.TODO(), "test", "port", "")
+	if err != nil {
+		t.Fatal("NewConn", err)
+	}
+	if conn1 == c.(*conn).Conn {
+		t.Error("Connection was reused after server-side close.")
+	}
+
+	// Cleanup
+	lconn = <-lconch
+	lconn.Close()
+	c.Close()
 }

--- a/core/pkg/fd_pool/interface.go
+++ b/core/pkg/fd_pool/interface.go
@@ -38,6 +38,8 @@ type FdPool interface {
 // It will return ErrNoServiceNodes if the nodes are depleted and no connection
 // attempt was made. If a connection was attempted but failed the error from
 // the dial function will be returned.
+// After Next any deadlines or other connection specific value set will be
+// removed so you will have to set them again.
 //
 // Reset can be used to start over from the start. In case of random strat a
 // new node will be chosen. It's rarely used.

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,8 @@ require (
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1 // indirect
-	golang.org/x/crypto v0.0.0-20180910181607-0e37d006457b // indirect
+	golang.org/x/crypto v0.0.0-20180910181607-0e37d006457b
+	golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
 	google.golang.org/grpc v1.15.0 // indirect
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect


### PR DESCRIPTION
Also contains a couple of small fixes for Go fd pools. It resets any deadline used before returning a put connection and fixes a bug in Next where it didn't clear conn when it fails.