### PR TITLE
Slog package

### DIFF
--- a/core/pkg/acl/acl.go
+++ b/core/pkg/acl/acl.go
@@ -8,12 +8,12 @@ package acl
 
 import (
 	"crypto"
-	"log"
 	"net"
 	"net/http"
 	"strings"
 
 	"github.com/schibsted/sebase/util/pkg/keyid"
+	"github.com/schibsted/sebase/util/pkg/slog"
 )
 
 type Access struct {
@@ -31,7 +31,7 @@ type Acl struct {
 }
 
 func (acl *Acl) InitDefault() {
-	log.Printf("Adding default ACL")
+	slog.Info("msg", "Adding default ACL")
 	p := func(s string) *string {
 		return &s
 	}
@@ -63,7 +63,7 @@ func (acl *Acl) check(v aclValues) bool {
 		if ac.RemoteAddr != nil {
 			ra, err := v.RemoteAddr()
 			if err != nil {
-				log.Printf("Failed to extract remote address: %s", err)
+				slog.Error("msg", "Failed to extract remote address", "error", err)
 				continue
 			}
 			if *ac.RemoteAddr != ra {
@@ -153,7 +153,7 @@ func (v *reqValues) KeyId() *string {
 	}
 	k, err := keyid.CertKeyId(v.req.TLS.PeerCertificates[0], crypto.SHA256)
 	if err != nil {
-		log.Printf("Failed to hash peer public key: %s\n", err)
+		slog.Error("msg", "Failed to hash peer public key", "error", err)
 		return nil
 	}
 	ret := k.String()

--- a/core/pkg/acl/acl.go
+++ b/core/pkg/acl/acl.go
@@ -31,7 +31,7 @@ type Acl struct {
 }
 
 func (acl *Acl) InitDefault() {
-	slog.Info("msg", "Adding default ACL")
+	slog.Info("Adding default ACL")
 	p := func(s string) *string {
 		return &s
 	}
@@ -63,7 +63,7 @@ func (acl *Acl) check(v aclValues) bool {
 		if ac.RemoteAddr != nil {
 			ra, err := v.RemoteAddr()
 			if err != nil {
-				slog.Error("msg", "Failed to extract remote address", "error", err)
+				slog.Error("Failed to extract remote address", "error", err)
 				continue
 			}
 			if *ac.RemoteAddr != ra {
@@ -153,7 +153,7 @@ func (v *reqValues) KeyId() *string {
 	}
 	k, err := keyid.CertKeyId(v.req.TLS.PeerCertificates[0], crypto.SHA256)
 	if err != nil {
-		slog.Error("msg", "Failed to hash peer public key", "error", err)
+		slog.Error("Failed to hash peer public key", "error", err)
 		return nil
 	}
 	ret := k.String()

--- a/core/pkg/fd_pool/common_test.go
+++ b/core/pkg/fd_pool/common_test.go
@@ -9,13 +9,15 @@ import (
 	"net"
 	"net/http"
 	"testing"
+
+	"github.com/schibsted/sebase/util/pkg/slog"
 )
 
 var l net.Listener
 var port int
 
 func init() {
-	DebugLog = defaultLogger(true)
+	slog.Debug.SetLogPrintf()
 
 	l, err := net.Listen("tcp", ":0")
 	if err != nil {

--- a/core/pkg/fd_pool/gopool.go
+++ b/core/pkg/fd_pool/gopool.go
@@ -390,7 +390,7 @@ func (pool *GoPool) NewConn(ctx context.Context, service, portKey, remoteAddr st
 		if pool.sdReg == nil {
 			return nil, NoSuchService
 		}
-		slog.Info("msg", "NewConn adding service", "service", service)
+		slog.Info("NewConn adding service", "service", service)
 		srv = pool.getService(service, DefaultRetries, DefaultConnectTimeout)
 		srv.sblock.Lock()
 		if srv.sdConn == nil {
@@ -567,7 +567,7 @@ func (c *conn) get(ctx context.Context, status sbalance.ConnStatus) (NetConn, er
 			c.SetDeadline(time.Time{})
 			c.connset.Unlock()
 			c.newConnect = false
-			slog.Debug("msg", "Reusing connection", "peer", c.connset.port.Addr)
+			slog.Debug("Reusing connection", "peer", c.connset.port.Addr)
 			return c, nil
 		}
 		c.connset.Unlock()
@@ -602,9 +602,9 @@ func checkDeadConnection(netc net.Conn) (dead bool) {
 				}
 				dead = true
 				if err != nil {
-					slog.Debug("msg", "Not returning dead connection", "error", err)
+					slog.Debug("Not returning dead connection", "error", err)
 				} else {
-					slog.Debug("msg", "Not returning dead connection", "eof", true)
+					slog.Debug("Not returning dead connection", "eof", true)
 				}
 			})
 		}

--- a/core/pkg/fd_pool/gopool.go
+++ b/core/pkg/fd_pool/gopool.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/schibsted/sebase/core/pkg/sd/sdr"
 	"github.com/schibsted/sebase/util/pkg/sbalance"
+	"github.com/schibsted/sebase/util/pkg/slog"
 	"github.com/schibsted/sebase/vtree/pkg/bconf"
 	"golang.org/x/sys/unix"
 )
@@ -389,7 +390,7 @@ func (pool *GoPool) NewConn(ctx context.Context, service, portKey, remoteAddr st
 		if pool.sdReg == nil {
 			return nil, NoSuchService
 		}
-		InfoLog.Printf("NewConn adding service %s", service)
+		slog.Info("msg", "NewConn adding service", "service", service)
 		srv = pool.getService(service, DefaultRetries, DefaultConnectTimeout)
 		srv.sblock.Lock()
 		if srv.sdConn == nil {
@@ -566,7 +567,7 @@ func (c *conn) get(ctx context.Context, status sbalance.ConnStatus) (NetConn, er
 			c.SetDeadline(time.Time{})
 			c.connset.Unlock()
 			c.newConnect = false
-			DebugLog.Printf("Reusing connection to %s", c.connset.port.Addr)
+			slog.Debug("msg", "Reusing connection", "peer", c.connset.port.Addr)
 			return c, nil
 		}
 		c.connset.Unlock()
@@ -601,9 +602,9 @@ func checkDeadConnection(netc net.Conn) (dead bool) {
 				}
 				dead = true
 				if err != nil {
-					DebugLog.Printf("Not returning dead connection: %s", err)
+					slog.Debug("msg", "Not returning dead connection", "error", err)
 				} else {
-					DebugLog.Printf("Not returning dead connection: EOF")
+					slog.Debug("msg", "Not returning dead connection", "eof", true)
 				}
 			})
 		}

--- a/core/pkg/fd_pool/http.go
+++ b/core/pkg/fd_pool/http.go
@@ -9,8 +9,8 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/schibsted/sebase/util/pkg/slog"
 	"github.com/schibsted/sebase/util/pkg/sbalance"
+	"github.com/schibsted/sebase/util/pkg/slog"
 )
 
 type HttpConn struct {
@@ -30,7 +30,7 @@ func HttpRequest(ctx context.Context, conn NetConn, tlsconf *tls.Config, req *ht
 		if err == nil {
 			return hc, nil
 		}
-		slog.Error("msg", "Failed to send HTTP request", "error", err)
+		slog.Error("Failed to send HTTP request", "error", err)
 		err = conn.Next(ctx, sbalance.Fail)
 		if err != nil {
 			return nil, err

--- a/core/pkg/fd_pool/http.go
+++ b/core/pkg/fd_pool/http.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/schibsted/sebase/util/pkg/slog"
 	"github.com/schibsted/sebase/util/pkg/sbalance"
 )
 
@@ -29,7 +30,7 @@ func HttpRequest(ctx context.Context, conn NetConn, tlsconf *tls.Config, req *ht
 		if err == nil {
 			return hc, nil
 		}
-		ErrLog.Printf("Failed to send HTTP request: %v", err)
+		slog.Error("msg", "Failed to send HTTP request", "error", err)
 		err = conn.Next(ctx, sbalance.Fail)
 		if err != nil {
 			return nil, err

--- a/core/pkg/fd_pool/log.go
+++ b/core/pkg/fd_pool/log.go
@@ -4,10 +4,9 @@ package fd_pool
 
 import "log"
 
-// Custom loggers support for fd_pool.
-// Used by plog to inject itself. Using plog directly from here would create a
-// circular dependency.
-// By default log.Printf is used, except for DebugLog which doesn't log.
+// Logger interface were used to log from this package.
+// It's no longer in use, the slog package is used instead.
+// It will be removed in the 2.0 release.
 type Logger interface {
 	Printf(format string, a ...interface{})
 }

--- a/core/pkg/fd_pool/sd.go
+++ b/core/pkg/fd_pool/sd.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/schibsted/sebase/util/pkg/slog"
 	"github.com/schibsted/sebase/core/pkg/sd/sdr"
 	"github.com/schibsted/sebase/vtree/pkg/bconf"
 )
@@ -49,7 +50,7 @@ func (p *GoPool) readSd(srvname string, srv *fdService) {
 		}
 		switch {
 		case msg.Type == sdr.EndOfBatch:
-			InfoLog.Printf("fd-pool: SD updating %s", srvname)
+			slog.Info("msg", "fd-pool: SD updating service", "service", srvname)
 			l, _ := p.UpdateHosts(context.Background(), srvname, conf)
 			if initial && l > 0 {
 				close(srv.sdConnInitial)
@@ -79,7 +80,7 @@ func parseConfig(dst *bconf.Node, hostkey, host, appl, src string) {
 	var data map[string]map[string]map[string]string
 	err := json.Unmarshal([]byte(src), &data)
 	if err != nil {
-		ErrLog.Printf("Error parsing SD config: %v", err)
+		slog.Error("msg", "Error parsing SD config", "error", err)
 		return
 	}
 	// Always add the disabled key, but don't touch a pre-set value.
@@ -102,7 +103,7 @@ func parseConfig(dst *bconf.Node, hostkey, host, appl, src string) {
 func parseHealth(dst *bconf.Node, hostkey, src string) {
 	v := "1"
 	src = strings.TrimSpace(src)
-	DebugLog.Printf("Hostkey %s new health %s", hostkey, src)
+	slog.Debug("msg", "New health for host", "hostkey", hostkey, "value", src)
 	if src == "up" {
 		v = "0"
 	}

--- a/core/pkg/fd_pool/sd.go
+++ b/core/pkg/fd_pool/sd.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/schibsted/sebase/util/pkg/slog"
 	"github.com/schibsted/sebase/core/pkg/sd/sdr"
+	"github.com/schibsted/sebase/util/pkg/slog"
 	"github.com/schibsted/sebase/vtree/pkg/bconf"
 )
 
@@ -50,7 +50,7 @@ func (p *GoPool) readSd(srvname string, srv *fdService) {
 		}
 		switch {
 		case msg.Type == sdr.EndOfBatch:
-			slog.Info("msg", "fd-pool: SD updating service", "service", srvname)
+			slog.Info("fd-pool: SD updating service", "service", srvname)
 			l, _ := p.UpdateHosts(context.Background(), srvname, conf)
 			if initial && l > 0 {
 				close(srv.sdConnInitial)
@@ -80,7 +80,7 @@ func parseConfig(dst *bconf.Node, hostkey, host, appl, src string) {
 	var data map[string]map[string]map[string]string
 	err := json.Unmarshal([]byte(src), &data)
 	if err != nil {
-		slog.Error("msg", "Error parsing SD config", "error", err)
+		slog.Error("Error parsing SD config", "error", err)
 		return
 	}
 	// Always add the disabled key, but don't touch a pre-set value.
@@ -103,7 +103,7 @@ func parseConfig(dst *bconf.Node, hostkey, host, appl, src string) {
 func parseHealth(dst *bconf.Node, hostkey, src string) {
 	v := "1"
 	src = strings.TrimSpace(src)
-	slog.Debug("msg", "New health for host", "hostkey", hostkey, "value", src)
+	slog.Debug("New health for host", "hostkey", hostkey, "value", src)
 	if src == "up" {
 		v = "0"
 	}

--- a/core/pkg/sapp/sapp.go
+++ b/core/pkg/sapp/sapp.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/schibsted/sebase/core/pkg/sd/etcd"
 	"github.com/schibsted/sebase/core/pkg/sd/sdr"
 	"github.com/schibsted/sebase/plog/pkg/plog"
+	"github.com/schibsted/sebase/util/pkg/slog"
 	"github.com/schibsted/sebase/vtree/pkg/bconf"
 )
 
@@ -83,7 +84,7 @@ func (s *Sapp) DefaultServer() *http.Server {
 	handler := s.AclMiddleware(srv.Handler)
 
 	errorLogger := func(m map[string]interface{}) {
-		plog.Default.Log("http_request", m)
+		plog.Log("http_request", m)
 	}
 
 	infoLogger := func(_ map[string]interface{}) {}
@@ -119,7 +120,7 @@ func (s *Sapp) AclMiddleware(h http.Handler) http.Handler {
 	}
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if !s.Acl.CheckRequest(req) {
-			plog.Error.Printf("Request URL %v forbidden by ACL", req.URL)
+			slog.Error("msg", "Request URL forbidden by ACL", "url", req.URL)
 			http.Error(rw, "Forbidden by ACL", http.StatusForbidden)
 			return
 		}
@@ -189,7 +190,7 @@ func getStrPtr(bconf bconf.Bconf) *string {
 }
 
 func initAclFromBconf(ac *acl.Acl, bconf bconf.Bconf) {
-	plog.Info.Printf("Adding ACL from bconf")
+	slog.Info("msg", "Adding ACL from bconf")
 	ac.Acl = nil
 	for _, b := range bconf.Slice() {
 		var entry acl.Access
@@ -197,14 +198,14 @@ func initAclFromBconf(ac *acl.Acl, bconf bconf.Bconf) {
 		if m := getStrPtr(b.Get("method")); m != nil {
 			entry.Method = *m
 		} else {
-			plog.Error.Printf("method not found in ACL, skipping")
+			slog.Error("msg", "Method not found in ACL, skipping")
 			continue
 		}
 
 		if p := getStrPtr(b.Get("path")); p != nil {
 			entry.Path = *p
 		} else {
-			plog.Error.Printf("path not found in ACL, skipping")
+			slog.Error("msg", "Path not found in ACL, skipping")
 			continue
 		}
 

--- a/core/pkg/sapp/sapp.go
+++ b/core/pkg/sapp/sapp.go
@@ -120,7 +120,7 @@ func (s *Sapp) AclMiddleware(h http.Handler) http.Handler {
 	}
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if !s.Acl.CheckRequest(req) {
-			slog.Error("msg", "Request URL forbidden by ACL", "url", req.URL)
+			slog.Error("Request URL forbidden by ACL", "url", req.URL)
 			http.Error(rw, "Forbidden by ACL", http.StatusForbidden)
 			return
 		}
@@ -190,7 +190,7 @@ func getStrPtr(bconf bconf.Bconf) *string {
 }
 
 func initAclFromBconf(ac *acl.Acl, bconf bconf.Bconf) {
-	slog.Info("msg", "Adding ACL from bconf")
+	slog.Info("Adding ACL from bconf")
 	ac.Acl = nil
 	for _, b := range bconf.Slice() {
 		var entry acl.Access
@@ -198,14 +198,14 @@ func initAclFromBconf(ac *acl.Acl, bconf bconf.Bconf) {
 		if m := getStrPtr(b.Get("method")); m != nil {
 			entry.Method = *m
 		} else {
-			slog.Error("msg", "Method not found in ACL, skipping")
+			slog.Error("Method not found in ACL, skipping")
 			continue
 		}
 
 		if p := getStrPtr(b.Get("path")); p != nil {
 			entry.Path = *p
 		} else {
-			slog.Error("msg", "Path not found in ACL, skipping")
+			slog.Error("Path not found in ACL, skipping")
 			continue
 		}
 

--- a/core/pkg/sapp/sd.go
+++ b/core/pkg/sapp/sd.go
@@ -26,7 +26,7 @@ func registerService(kapi client.KeysAPI, ttl time.Duration, service, hostkey, h
 		newdir = true
 	}
 	if err != nil {
-		slog.Error("msg", "Error updating directory", "error", err)
+		slog.Error("Error updating directory", "error", err)
 		newdir = true
 	}
 
@@ -39,7 +39,7 @@ func registerService(kapi client.KeysAPI, ttl time.Duration, service, hostkey, h
 		if cerr, ok := err.(client.Error); ok && cerr.Code == client.ErrorCodeNodeExist {
 			// Means the prevExist check failed, which is ok.
 		} else {
-			slog.Error("msg", "Error setting config in etcd", "error", err)
+			slog.Error("Error setting config in etcd", "error", err)
 		}
 	}
 
@@ -57,7 +57,7 @@ func registerService(kapi client.KeysAPI, ttl time.Duration, service, hostkey, h
 	if newval {
 		_, err = kapi.Set(context.Background(), dir+"/health", health, nil)
 		if err != nil {
-			slog.Error("msg", "Error setting health in etcd", "error", err)
+			slog.Error("Error setting health in etcd", "error", err)
 		}
 	}
 }
@@ -68,7 +68,7 @@ func unregisterService(kapi client.KeysAPI, service, hostkey string) {
 
 	_, err := kapi.Delete(context.Background(), dir, &client.DeleteOptions{Recursive: true, Dir: true})
 	if err != nil {
-		slog.Error("msg", "Error deleting service in etcd", "error", err)
+		slog.Error("Error deleting service in etcd", "error", err)
 	}
 }
 
@@ -76,7 +76,7 @@ func hostkeyRandom() string {
 	var id [16]byte
 	n, err := rand.Read(id[:])
 	if err != nil {
-		slog.Critical("msg", "Failed to generate random hostkey", "error", err)
+		slog.Critical("Failed to generate random hostkey", "error", err)
 		panic("Failed to generate random hostkey")
 	}
 	if n != len(id) {
@@ -95,13 +95,13 @@ func (s *Sapp) healthCheck() (health string) {
 	// XXX - should be overridable from config
 	url := s.healthCheckEndpoint
 	if url == "" {
-		slog.Info("msg", "No healthcheck url configured")
+		slog.Info("No healthcheck url configured")
 		return "down"
 	}
 
 	resp, err := s.healthCheckClient.Get(url)
 	if err != nil {
-		slog.Warning("msg", "Error checking health, assuming service is down. ", "error", err)
+		slog.Warning("Error checking health, assuming service is down. ", "error", err)
 		return "down"
 	}
 	defer resp.Body.Close()

--- a/core/pkg/sapp/sd.go
+++ b/core/pkg/sapp/sd.go
@@ -8,12 +8,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"time"
 
 	"github.com/coreos/etcd/client"
+	"github.com/schibsted/sebase/util/pkg/slog"
 )
 
 func registerService(kapi client.KeysAPI, ttl time.Duration, service, hostkey, health, prevHealth, config, prevConfig string) {
@@ -26,7 +26,7 @@ func registerService(kapi client.KeysAPI, ttl time.Duration, service, hostkey, h
 		newdir = true
 	}
 	if err != nil {
-		log.Print("Error updating directory: ", err)
+		slog.Error("msg", "Error updating directory", "error", err)
 		newdir = true
 	}
 
@@ -39,7 +39,7 @@ func registerService(kapi client.KeysAPI, ttl time.Duration, service, hostkey, h
 		if cerr, ok := err.(client.Error); ok && cerr.Code == client.ErrorCodeNodeExist {
 			// Means the prevExist check failed, which is ok.
 		} else {
-			log.Print(err)
+			slog.Error("msg", "Error setting config in etcd", "error", err)
 		}
 	}
 
@@ -57,7 +57,7 @@ func registerService(kapi client.KeysAPI, ttl time.Duration, service, hostkey, h
 	if newval {
 		_, err = kapi.Set(context.Background(), dir+"/health", health, nil)
 		if err != nil {
-			log.Print(err)
+			slog.Error("msg", "Error setting health in etcd", "error", err)
 		}
 	}
 }
@@ -68,7 +68,7 @@ func unregisterService(kapi client.KeysAPI, service, hostkey string) {
 
 	_, err := kapi.Delete(context.Background(), dir, &client.DeleteOptions{Recursive: true, Dir: true})
 	if err != nil {
-		log.Fatal(err)
+		slog.Error("msg", "Error deleting service in etcd", "error", err)
 	}
 }
 
@@ -76,10 +76,11 @@ func hostkeyRandom() string {
 	var id [16]byte
 	n, err := rand.Read(id[:])
 	if err != nil {
-		log.Fatal(err)
+		slog.Critical("msg", "Failed to generate random hostkey", "error", err)
+		panic("Failed to generate random hostkey")
 	}
 	if n != len(id) {
-		log.Fatal("Short read without error")
+		panic("Short read without error")
 	}
 	id[6] = (id[6] & 0x0F) | 0x40
 	id[8] = (id[8] & 0x3F) | 0x80
@@ -94,13 +95,13 @@ func (s *Sapp) healthCheck() (health string) {
 	// XXX - should be overridable from config
 	url := s.healthCheckEndpoint
 	if url == "" {
-		log.Print("No healthcheck url configured")
+		slog.Info("msg", "No healthcheck url configured")
 		return "down"
 	}
 
 	resp, err := s.healthCheckClient.Get(url)
 	if err != nil {
-		log.Print("Error checking health, assuming service is down. ", err)
+		slog.Warning("msg", "Error checking health, assuming service is down. ", "error", err)
 		return "down"
 	}
 	defer resp.Body.Close()

--- a/core/pkg/sd/etcd/watcher_test.go
+++ b/core/pkg/sd/etcd/watcher_test.go
@@ -14,8 +14,8 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/client"
+	"github.com/schibsted/sebase/util/pkg/slog"
 	"github.com/schibsted/sebase/core/pkg/sd/sdr"
-	"github.com/schibsted/sebase/plog/pkg/plog"
 	"github.com/schibsted/sebase/vtree/pkg/bconf"
 )
 
@@ -75,7 +75,7 @@ const (
 )
 
 func init() {
-	plog.Setup("etcd-test", "debug")
+	slog.Debug.SetLogPrintf()
 }
 
 type handler struct {

--- a/core/pkg/sd/sdr/source.go
+++ b/core/pkg/sd/sdr/source.go
@@ -86,7 +86,7 @@ func (sdr *Registry) AddSources(conf bconf.Bconf) (n int, err error) {
 			errs = append(errs, err)
 		} else if sval != nil {
 			sdr.sources[skey] = sval
-			slog.Info("msg", "Sd registry source added", "type", src.SdrName(), "value", value)
+			slog.Info("Sd registry source added", "type", src.SdrName(), "value", value)
 			n++
 		}
 	}

--- a/core/pkg/sd/sdr/source.go
+++ b/core/pkg/sd/sdr/source.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"log"
 
+	"github.com/schibsted/sebase/util/pkg/slog"
 	"github.com/schibsted/sebase/vtree/pkg/bconf"
 )
 
@@ -86,7 +86,7 @@ func (sdr *Registry) AddSources(conf bconf.Bconf) (n int, err error) {
 			errs = append(errs, err)
 		} else if sval != nil {
 			sdr.sources[skey] = sval
-			log.Printf("Sd registry source %s at %s added", src.SdrName(), value)
+			slog.Info("msg", "Sd registry source added", "type", src.SdrName(), "value", value)
 			n++
 		}
 	}

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -42,25 +42,27 @@ passed to plog-store with a generic `log` tag.
 
 ## Go
 
-Options are: `plog.Level.Printf`, `plog.LogDict`, `log.Printf`
+Options are: `plog.Level.Printf`, `plog.LogMsg`, `log.Printf`
 
 ### `plog.Level.Printf`
 
 This closely matches the `log_printf` in being easy to use for generic messages.
+However, it's often more useful to use `plog.Level.LogMsg` for more structured
+logging.
 
-### `plog.LogDict`
+### `plog.LogMsg`
 
 Example:
 
-	plog.LogDict("mymsg", "msg", "my message", "mykey", "myvalue")
+	plog.LogMsg("mymsg", "my message", "mykey", "myvalue")
 
 Use for structured/tagged logging. `mymsg` is the top level tag. Also exists
 on the levels, then the top level tag is skipped:
 
-	plog.Debug.LogDict("msg", "my message", "mykey", "myvalue")
+	plog.Debug.LogMsg("my message", "mykey", "myvalue")
 
-Using the "msg" key with a human readable message is the convention when using
-level based logging, but can be skipped for custom tags.
+The first argument is a human readable message. If you want to skip that you
+can use LogDict or Log instead.
 
 There are other options in plog as well, such as `plog.Log` if you wish to log
 any single value, or `plog.Default.OpenDict` / `OpenList` to open sub contexts.

--- a/plog/pkg/plog/level.go
+++ b/plog/pkg/plog/level.go
@@ -157,10 +157,17 @@ func (l Level) Panicf(format string, v ...interface{}) {
 	panic(fmt.Sprintf(format, v...))
 }
 
-// Convience function that calls LogDict with l.Code() as key. This breaks
-// using strings as values for the standard log levels but that's just a
-// recommendation regardless. As a new recommendation, use a "msg" key
-// with a human readable message when using this function.
+// Convience function that calls LogDict with l.Code() as key. This is
+// deprecated in favor of LogMsg which enforces a human readable message.
+// This function will be removed in version 2.0.
 func (l Level) LogDict(kvs ...interface{}) error {
 	return LogDict(l.Code(), kvs...)
+}
+
+// Convience function that calls LogMsg with l.Code() as key. The msg
+// parameter contains a human readable message, while the rest are passed
+// to slog.KVsMap to convert to a dictionary.
+// This is not a printf-like function, despite the signature.
+func (l Level) LogMsg(msg string, kvs ...interface{}) {
+	LogMsg(l.Code(), msg, kvs...)
 }

--- a/plog/pkg/plog/logging.go
+++ b/plog/pkg/plog/logging.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"log"
 
+	"github.com/schibsted/sebase/util/pkg/slog"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -16,9 +17,10 @@ import (
 var SetupLevel = Info
 
 // Initializes the default plog context and changes SetupLevel based on a
-// string.  Also calls log.SetOutput(plog.Info) to redirect log.Printf output
-// to this package and log.SetFlags(0). Finally checks if FallbackWriter is a
-// TTY. If so, changes FallbackFormatter to FallbackFormatterSimple.
+// string. Changes the functions used by the slog package to plog and also
+// calls log.SetOutput(plog.Info) to redirect log.Printf output to this package
+// as well as log.SetFlags(0). Finally checks if FallbackWriter is a TTY. If
+// so, changes FallbackFormatter to FallbackFormatterSimple.
 func Setup(appname, lvl string) {
 	SetupLevel = LogLevel(lvl, SetupLevel)
 	Default = NewPlogLog(appname)
@@ -33,6 +35,11 @@ func Setup(appname, lvl string) {
 	if ok && terminal.IsTerminal(int(fd.Fd())) {
 		FallbackFormatter = FallbackFormatterSimple
 	}
+	slog.Critical.SetErrf(Critical.LogDict)
+	slog.Error.SetErrf(Error.LogDict)
+	slog.Warning.SetErrf(Warning.LogDict)
+	slog.Info.SetErrf(Info.LogDict)
+	slog.Debug.SetErrf(Debug.LogDict)
 }
 
 // Closes Default, disconnecting from the logging server.

--- a/plog/pkg/plog/logging.go
+++ b/plog/pkg/plog/logging.go
@@ -7,6 +7,7 @@ package plog
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 
 	"github.com/schibsted/sebase/util/pkg/slog"
@@ -35,11 +36,11 @@ func Setup(appname, lvl string) {
 	if ok && terminal.IsTerminal(int(fd.Fd())) {
 		FallbackFormatter = FallbackFormatterSimple
 	}
-	slog.Critical.SetErrf(Critical.LogDict)
-	slog.Error.SetErrf(Error.LogDict)
-	slog.Warning.SetErrf(Warning.LogDict)
-	slog.Info.SetErrf(Info.LogDict)
-	slog.Debug.SetErrf(Debug.LogDict)
+	slog.Critical = Critical.LogMsg
+	slog.Error = Error.LogMsg
+	slog.Warning = Warning.LogMsg
+	slog.Info = Info.LogMsg
+	slog.Debug = Debug.LogMsg
 }
 
 // Closes Default, disconnecting from the logging server.
@@ -61,11 +62,42 @@ func Log(key string, value interface{}) error {
 	return err
 }
 
-// Log a JSON dictionary from the variadic arguments, alternating keys and
-// values, key first. Logs to Default or to FallbackWriter if nil
+// Log a JSON dictionary from the variadic arguments, which are parsed with
+// slog.KVsMap. Logs to Default or to FallbackWriter if nil.
 // See Plog.LogDict for more information.
 func LogDict(key string, kvs ...interface{}) error {
-	return Log(key, kvsToDict(kvs))
+	return Log(key, slog.KVsMap(kvs...))
+}
+
+// Log a message together with a JSON dictionary from the variadic arguments,
+// which are parse by slog.KVsMap. Logs to Default or to FallbackWriter if nil.
+// See Plog.LogMsg for more information.
+func LogMsg(key, msg string, kvs ...interface{}) {
+	m := slog.KVsMap(kvs...)
+	m["msg"] = msg
+	errWrap(Log, key, m)
+}
+
+// errWrap calls f with key and value. If it returns an error, it tries it best
+// to convert value into something that won't error on json.Marshal and tries again.
+// If possible it adds the error with a "log-error" key.
+func errWrap(f func(key string, value interface{}) error, key string, value interface{}) {
+	err := f(key, value)
+	if err == nil {
+		return
+	}
+	// Error, convert all values to strings.
+	switch value := value.(type) {
+	case map[string]interface{}:
+		m := make(map[string]interface{}, len(value))
+		for k, v := range value {
+			m[k] = fmt.Sprint(v)
+		}
+		m["log-error"] = err.Error()
+		f(key, m)
+	default:
+		f(key, fmt.Sprint(value))
+	}
 }
 
 // Shorthand for Info.Print

--- a/plog/pkg/plog/plog.go
+++ b/plog/pkg/plog/plog.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/schibsted/sebase/plog/internal/pkg/plogproto"
+	"github.com/schibsted/sebase/util/pkg/slog"
 )
 
 // A plog context is an object opened in the log server. The server will
@@ -157,38 +158,28 @@ func (ctx *Plog) LogAsString(key string, value []byte) {
 	}
 }
 
-// Log a JSON dictionary from the variadic arguments, alternating keys and
-// values, key first. Note that the first argument is not part of the
-// dictionary, it's the message key.
-// Error interface values are special handled, converted to the error message.
+// Log a JSON dictionary from the variadic arguments, which are parsed with
+// slog.KVsMap.  Note that the first argument is not part of the dictionary,
+// it's the message key.
 // Might return errors from json.Marshal.
 func (ctx *Plog) LogDict(key string, kvs ...interface{}) error {
 	if ctx == nil {
 		return nil
 	}
-	return ctx.Log(key, kvsToDict(kvs))
+	return ctx.Log(key, slog.KVsMap(kvs...))
 }
 
-func kvsToDict(kvs []interface{}) map[string]interface{} {
-	m := make(map[string]interface{}, len(kvs)/2)
-	for i := 0; i < len(kvs); i += 2 {
-		var v interface{}
-		if i < len(kvs)-1 {
-			v = kvs[i+1]
-			if err, ok := v.(error); ok {
-				v = err.Error()
-			}
-		}
-		switch k := kvs[i].(type) {
-		case string:
-			m[k] = v
-		case fmt.Stringer:
-			m[k.String()] = v
-		default:
-			m[fmt.Sprint(k)] = v
-		}
+// Log a human readable message with a JSON dictionary from the variadic
+// arguments, which are parsed with slog.KVsMap.
+// This function does not return errors. If json encoding fails it
+// converts to a string and tries again, adding a "log-error" key.
+func (ctx *Plog) LogMsg(key, msg string, kvs ...interface{}) {
+	if ctx == nil {
+		return
 	}
-	return m
+	m := slog.KVsMap(kvs...)
+	m["msg"] = msg
+	errWrap(ctx.Log, key, m)
 }
 
 // Log raw JSON encoded data in value. You must make sure the JSON is valid,

--- a/plog/pkg/plog/plog.go
+++ b/plog/pkg/plog/plog.go
@@ -160,6 +160,7 @@ func (ctx *Plog) LogAsString(key string, value []byte) {
 // Log a JSON dictionary from the variadic arguments, alternating keys and
 // values, key first. Note that the first argument is not part of the
 // dictionary, it's the message key.
+// Error interface values are special handled, converted to the error message.
 // Might return errors from json.Marshal.
 func (ctx *Plog) LogDict(key string, kvs ...interface{}) error {
 	if ctx == nil {
@@ -174,6 +175,9 @@ func kvsToDict(kvs []interface{}) map[string]interface{} {
 		var v interface{}
 		if i < len(kvs)-1 {
 			v = kvs[i+1]
+			if err, ok := v.(error); ok {
+				v = err.Error()
+			}
 		}
 		switch k := kvs[i].(type) {
 		case string:

--- a/util/pkg/slog/kv.go
+++ b/util/pkg/slog/kv.go
@@ -1,0 +1,68 @@
+package slog
+
+import "fmt"
+
+// KV can be used instead of a key-value pair in KVsMap function and any
+// function that use it, e.g. DefaultLogger.LogMsg.
+type KV map[string]interface{}
+
+// ToMap returns kvs, it implements the ToMap interface.
+func (kvs KV) ToMap() map[string]interface{} {
+	return kvs
+}
+
+// ToMap is used to check arguments passed to KVsMap. If this function is
+// implemented the keys and values returned are added to the KVsMap return
+// value.
+type ToMap interface {
+	ToMap() map[string]interface{}
+}
+
+// KVsMap converts a set of key-value pairs into a map. Each argument read
+// is type checked. If it's a string, the next argument is used as a value.
+// If it's a map[string]interface{} then the contents is copied to the return value.
+// Same thing if it implements the ToMap interface, then the map contents is
+// copied.
+// If none of the types match, fmt.Sprint is used to convert to a string and the
+// next argument is used as value. Sometimes this happens if you forget to add
+// ... to expand the array when calling this function
+// Error interface values are special handled, converted to the error message.
+func KVsMap(kvs ...interface{}) map[string]interface{} {
+	m := make(map[string]interface{}, len(kvs)/2)
+	for i := 0; i < len(kvs); i++ {
+		switch k := kvs[i].(type) {
+		case string:
+			var v interface{}
+			if i+1 < len(kvs) {
+				i++
+				v = kvsMapV(kvs[i])
+			}
+			m[k] = v
+		case map[string]interface{}:
+			for mk, v := range k {
+				m[mk] = kvsMapV(v)
+			}
+		case ToMap:
+			for mk, v := range k.ToMap() {
+				m[mk] = kvsMapV(v)
+			}
+		default:
+			mk := fmt.Sprint(k)
+			var v interface{}
+			if i+1 < len(kvs) {
+				i++
+				v = kvsMapV(kvs[i])
+			}
+			m[mk] = v
+		}
+	}
+	return m
+}
+
+func kvsMapV(v interface{}) interface{} {
+	switch v := v.(type) {
+	case error:
+		return v.Error()
+	}
+	return v
+}

--- a/util/pkg/slog/log.go
+++ b/util/pkg/slog/log.go
@@ -1,0 +1,100 @@
+// Copyright 2019 Schibsted
+
+// Package slog is used to log from the other sebase packages.
+// The purpose of this is to not depend on a particular log package since
+// different users might want to use different packages.
+// Plog will install itself here if used, but the default values simply creates
+// a string and calls log.Printf.
+package slog
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+)
+
+// Logger is the function type used to log.
+//
+// The arguments are alternated keys as strings and values which can be any
+// type, keys first. The first key given will be "msg" and the first value will
+// be a string with a human readable message.  If you call this package, make
+// sure to follow these rules as there's likely to be a panic otherwise.
+type Logger func(kvs ...interface{})
+
+// DefaultLogger is used as a default logger, wrapping a Printf like function.
+type DefaultLogger struct {
+	Logf func(format string, v ...interface{})
+}
+
+// LogDict creates a string and calls the log.Printf like function
+// contained if not nil.
+// Error interface values are special handled, converted to the error message.
+func (d DefaultLogger) LogDict(kvs ...interface{}) {
+	if d.Logf == nil {
+		return
+	}
+	var msg string
+	m := make(map[string]interface{}, len(kvs)/2)
+	for i := 0; i < len(kvs); i += 2 {
+		k := kvs[i].(string)
+		var v interface{}
+		if i < len(kvs)-1 {
+			v = kvs[i+1]
+		}
+		if err, ok := v.(error); ok {
+			v = err.Error()
+		}
+		if k == "msg" {
+			msg = v.(string)
+		} else {
+			m[k] = v
+		}
+	}
+	if len(m) == 0 {
+		d.Logf("%s", msg)
+		return
+	}
+	data, err := json.Marshal(m)
+	var v interface{} = data
+	if err != nil {
+		v = fmt.Sprint(m)
+	}
+	d.Logf("%s: %s", msg, v)
+}
+
+var (
+	Critical Logger = DefaultLogger{log.Printf}.LogDict
+	Error    Logger = DefaultLogger{log.Printf}.LogDict
+	Warning  Logger = DefaultLogger{log.Printf}.LogDict
+	Info     Logger = DefaultLogger{log.Printf}.LogDict
+	Debug    Logger = DefaultLogger{nil}.LogDict
+)
+
+// SetLogPrintf sets the receiver to log to log.Printf via the DefaultLogger type.
+// It's a convenience function. For example you can enable debug logging with
+// slog.Debug.SetLogPrintf()
+func (logger *Logger) SetLogPrintf() {
+	*logger = DefaultLogger{log.Printf}.LogDict
+}
+
+// Disable sets the receiver to a value discaring the logs.
+func (logger *Logger) Disabe() {
+	*logger = DefaultLogger{nil}.LogDict
+}
+
+// SetErrf sets the receiver to a function that can return errors. When that
+// happens, log.Printf is called as a backup with a "log-error" indicating the
+// error.
+func (logger *Logger) SetErrf(f func(kvs ...interface{}) error) {
+	*logger = func(kvs ...interface{}) {
+		err := f(kvs...)
+		if err == nil {
+			return
+		}
+		nkvs := make([]interface{}, len(kvs)+2)
+		copy(nkvs, kvs)
+		nkvs[len(kvs)] = "log-error"
+		nkvs[len(kvs)+1] = err
+		DefaultLogger{log.Printf}.LogDict(nkvs)
+	}
+}


### PR DESCRIPTION
As mentioned in the first commit, the idea is to allow use of our packages with any log package. For that a small hook package called slog is added, where the logger to use can be injected. Plog will inject itself i used, sapp will also inject plog.