### PR TITLE
Split gopool checkDeadConnection into Linux and non-Linux file.

### DIFF
--- a/core/pkg/fd_pool/gopool_linux.go
+++ b/core/pkg/fd_pool/gopool_linux.go
@@ -1,0 +1,41 @@
+// +build linux
+
+package fd_pool
+
+import (
+	"net"
+	"syscall"
+
+	"github.com/schibsted/sebase/util/pkg/slog"
+	"golang.org/x/sys/unix"
+)
+
+func checkDeadConnection(netc net.Conn) (dead bool) {
+	// If possible, test that the connection is valid.
+	// I've tested using netc.Write for this, but it didn't work.
+	// Instead call syscall.Poll directly. This is Linux only
+	// because it only works with the POLLRDHUP flag which is linux specific.
+	type rawconn interface {
+		SyscallConn() (syscall.RawConn, error)
+	}
+	if sc, ok := netc.(rawconn); ok {
+		if scc, err := sc.SyscallConn(); err == nil {
+			scc.Control(func(fd uintptr) {
+				pfd := []unix.PollFd{
+					{int32(fd), unix.POLLHUP | unix.POLLRDHUP, 0},
+				}
+				n, err := unix.Poll(pfd, 0)
+				if n == 0 {
+					return
+				}
+				dead = true
+				if err != nil {
+					slog.Debug("Not returning dead connection", "error", err)
+				} else {
+					slog.Debug("Not returning dead connection", "eof", true)
+				}
+			})
+		}
+	}
+	return
+}

--- a/core/pkg/fd_pool/gopool_others.go
+++ b/core/pkg/fd_pool/gopool_others.go
@@ -1,0 +1,40 @@
+//+build !linux
+
+package fd_pool
+
+import (
+	"net"
+	"syscall"
+
+	"github.com/schibsted/sebase/util/pkg/slog"
+	"golang.org/x/sys/unix"
+)
+
+func checkDeadConnection(netc net.Conn) (dead bool) {
+	// If possible, test that the connection is valid.
+	// I've tested using netc.Write for this, but it didn't work.
+	// Instead call syscall.Poll directly.
+	type rawconn interface {
+		SyscallConn() (syscall.RawConn, error)
+	}
+	if sc, ok := netc.(rawconn); ok {
+		if scc, err := sc.SyscallConn(); err == nil {
+			scc.Control(func(fd uintptr) {
+				pfd := []unix.PollFd{
+					{int32(fd), unix.POLLHUP, 0},
+				}
+				n, err := unix.Poll(pfd, 0)
+				if n == 0 {
+					return
+				}
+				dead = true
+				if err != nil {
+					slog.Debug("Not returning dead connection", "error", err)
+				} else {
+					slog.Debug("Not returning dead connection", "eof", true)
+				}
+			})
+		}
+	}
+	return
+}

--- a/core/pkg/fd_pool/gopool_test.go
+++ b/core/pkg/fd_pool/gopool_test.go
@@ -219,6 +219,11 @@ func TestReused(t *testing.T) {
 	}
 
 	// Check again but close from server-side. NewConn should now return a new connection.
+	// I haven't found a way to make this check work on OpenBSD yet.
+	if runtime.GOOS == "openbsd" {
+		c.Close()
+		t.Skip("Not yet implemented for OpenBSD.")
+	}
 	c.Put()
 	lconn := <-lconch
 	lconn.Close()


### PR DESCRIPTION
The only difference is that Linux adds POLLRDHUP to the flags sent to
poll. I should of course have checked that the code worked on multiple
systems rather than just assuming.