### PR TITLE
Add buffered output to plogd when writing to a file.

### DIFF
--- a/plog/bin/plogd/main.go
+++ b/plog/bin/plogd/main.go
@@ -248,8 +248,7 @@ func main() {
 	case *logstashAddr != "":
 		dataStore.Output, err = NewNetWriter("tcp", *logstashAddr)
 	case *jsonFile != "":
-		w := &jsonFileWriter{path: *jsonFile}
-		err = w.rotate()
+		w, err := NewJsonFileWriter(*jsonFile)
 		if err == nil {
 			dataStore.Output = w
 			s.fileWriter = w

--- a/plog/bin/plogd/server_test.go
+++ b/plog/bin/plogd/server_test.go
@@ -84,7 +84,7 @@ func TestRotate(t *testing.T) {
 	if w.code != 200 && w.code != 0 { // 0 => unset, defaults to 200
 		t.Errorf("Got bad HTTP status %d", w.code)
 	}
-	if jf.w == nil || jf.Closer == nil {
+	if jf.w == nil || jf.closer == nil {
 		t.Errorf("Writer or Closer were unset. Got %#v", jf)
 	}
 	defer jf.Close()
@@ -92,7 +92,7 @@ func TestRotate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	jfinfo, err := jf.w.(*os.File).Stat()
+	jfinfo, err := jf.closer.(*os.File).Stat()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/test.dockerfile
+++ b/test/test.dockerfile
@@ -6,7 +6,7 @@ ENV GOPATH=/go
 ENV PATH=/go/bin:/usr/local/go/bin:$PATH
 
 RUN apt-get update && apt-get install -y curl etcd g++ gcc git gperf jq libbsd-dev libcurl4-openssl-dev libicu-dev libpcre3-dev libssl-dev libyajl-dev make ninja-build protobuf-c-compiler python && apt-get clean
-RUN curl https://dl.google.com/go/go1.11.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 RUN go get github.com/schibsted/sebuild/cmd/seb
 # Python is only needed for test, should try to remove it maybe.
 


### PR DESCRIPTION
After these changes profiling shows less then half time spend in plog functions compared to before during a load with heavy logging. The log is flushed at least once per second.