### PR TITLE
Empty remote addr should use a nil sbalance seed.

### DIFF
--- a/core/pkg/fd_pool/gopool_test.go
+++ b/core/pkg/fd_pool/gopool_test.go
@@ -198,7 +198,7 @@ func TestReused(t *testing.T) {
 	}()
 
 	// Setup
-	port = ln.Addr().(*net.TCPAddr).Port
+	port := ln.Addr().(*net.TCPAddr).Port
 	pool := NewGoPool(nil)
 	defer pool.Close()
 	pool.AddSingle(context.TODO(), "test", "tcp", fmt.Sprintf("127.0.0.1:%d", port), DefaultRetries, 1*time.Second)
@@ -239,4 +239,23 @@ func TestReused(t *testing.T) {
 	lconn = <-lconch
 	lconn.Close()
 	c.Close()
+}
+
+func TestEmptyRemoteAddr(t *testing.T) {
+	pool := NewGoPool(nil)
+	defer pool.Close()
+	err := pool.AddSingle(context.TODO(), "test", "tcp", fmt.Sprintf("localhost:%d", port), 1, 1*time.Second)
+	if err != nil {
+		t.Fatal("addsingle", err)
+	}
+
+	c, err := pool.NewConn(context.TODO(), "test", "port", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	if c.(*conn).sbseed != nil {
+		t.Errorf("Expected nil sbseed, got %#v", c.(*conn).sbseed)
+	}
 }

--- a/test/test.dockerfile
+++ b/test/test.dockerfile
@@ -2,8 +2,7 @@
 
 FROM ubuntu:xenial
 
-ENV GOPATH=/go
-ENV PATH=/go/bin:/usr/local/go/bin:$PATH
+ENV PATH=/root/go/bin:/usr/local/go/bin:$PATH
 
 RUN apt-get update && apt-get install -y curl etcd g++ gcc git gperf jq libbsd-dev libcurl4-openssl-dev libicu-dev libpcre3-dev libssl-dev libyajl-dev make ninja-build protobuf-c-compiler python && apt-get clean
 RUN curl https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz | tar -C /usr/local -xzf -

--- a/test/travis.sh
+++ b/test/travis.sh
@@ -5,9 +5,6 @@ set -e
 img=$(docker build -q - < test/test.dockerfile)
 docker run --volume "$PWD:/sebase" -t --rm "$img" bash -e -x -c "
 	cd /sebase
-	mkdir -p build/_go
-	# Use a local gopath for pkg caching.
-	export GOPATH=\$PWD/build/_go:\$GOPATH
 	seb
 	build/dev/bin/regress-runner --travis-fold
 


### PR DESCRIPTION
Nil seed switches to the random strat, but empty slice seed does not. It
feels best to change this at the fd pool level since sbalance can be
used for other things some of which might want empty slice seed to work
for hash strat.