### PR TITLE
Go lint all plog packages.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 	gopkg.in/yaml.v2 v2.2.1
 )
+
+go 1.12

--- a/plog/bin/plogd/counter.go
+++ b/plog/bin/plogd/counter.go
@@ -2,11 +2,13 @@
 
 package main
 
+// CountOutput wraps a SessionOutput with a delta counter.
 type CountOutput struct {
 	SessionOutput
 	counts map[string]int
 }
 
+// NewCountOutput wraps a session output as a count output.
 func NewCountOutput(wrapped SessionOutput) *CountOutput {
 	return &CountOutput{SessionOutput: wrapped}
 }
@@ -34,6 +36,8 @@ func (out *CountOutput) Write(key string, value interface{}) error {
 	return out.SessionOutput.Write(key, value)
 }
 
+// Close undoes all deltas in the countoutut and closes the underlying session
+// output.
 func (out *CountOutput) Close(proper, lastRef bool) {
 	for k, f := range out.counts {
 		out.SessionOutput.Write(k, -f)

--- a/plog/bin/plogd/io_writer.go
+++ b/plog/bin/plogd/io_writer.go
@@ -78,7 +78,7 @@ type jsonFileWriter struct {
 	sync.Mutex
 }
 
-func NewJsonFileWriter(file string) (*jsonFileWriter, error) {
+func newJSONFileWriter(file string) (*jsonFileWriter, error) {
 	w := &jsonFileWriter{path: file}
 	err := w.rotate()
 	if err != nil {

--- a/plog/bin/plogd/main.go
+++ b/plog/bin/plogd/main.go
@@ -31,7 +31,7 @@ func handleOpenContext(sessionStore *SessionStorage, dataStore *DataStorage, par
 	var err error
 	var stype plogproto.CtxType
 	if len(info.Key) == 0 {
-		return nil, fmt.Errorf("No context key given.")
+		return nil, fmt.Errorf("no context key given")
 	}
 	if info.Ctxtype == nil {
 		info.Ctxtype = new(plogproto.CtxType)
@@ -39,7 +39,7 @@ func handleOpenContext(sessionStore *SessionStorage, dataStore *DataStorage, par
 	switch *info.Ctxtype {
 	case plogproto.CtxType_log, plogproto.CtxType_state, plogproto.CtxType_count:
 		if parentSess != nil {
-			return nil, fmt.Errorf("Parent context id not allowed for this context type.")
+			return nil, fmt.Errorf("parent context id not allowed for this context type")
 		}
 		output, err = dataStore.findOutput(info.Key[0], *info.Ctxtype)
 		stype = *info.Ctxtype
@@ -54,7 +54,7 @@ func handleOpenContext(sessionStore *SessionStorage, dataStore *DataStorage, par
 		}
 	case plogproto.CtxType_dict, plogproto.CtxType_list:
 		if parentSess == nil {
-			return nil, fmt.Errorf("Parent context id is required for this context type.")
+			return nil, fmt.Errorf("parent context id is required for this context type")
 		}
 		switch *info.Ctxtype {
 		case plogproto.CtxType_list:
@@ -166,7 +166,7 @@ func handleConnection(ctx context.Context, sessionStore *SessionStorage, dataSto
 	}
 }
 
-var Work sync.WaitGroup
+var work sync.WaitGroup
 var sigCh = make(chan os.Signal)
 var quitDoneCh = make(chan struct{})
 
@@ -181,10 +181,10 @@ func listen(ctx context.Context, sessionStore *SessionStorage, dataStore *DataSt
 			break
 		}
 
-		Work.Add(1)
+		work.Add(1)
 		go func() {
 			handleConnection(ctx, sessionStore, dataStore, conn)
-			Work.Done()
+			work.Done()
 		}()
 	}
 }
@@ -237,10 +237,6 @@ func main() {
 	pidfile := flag.String("pidfile", "", "Write PID to this file. Truncated early but the pid is written once the service is ready to accept answers")
 	subprog := flag.String("subprog", "", "If set, split the prog field on + and add the second value to the output with this key.")
 
-	if os.Getenv("GOMAXPROCS") == "" && strings.HasPrefix(runtime.Version(), "go1.4") {
-		runtime.GOMAXPROCS(20)
-	}
-
 	flag.Parse()
 
 	var pidF *os.File
@@ -264,17 +260,17 @@ func main() {
 	switch {
 	case *logstashAddr != "":
 		if *outPlugin != "" || *jsonFile != "" {
-			err = fmt.Errorf("Only one of -json, -file and -output-plugin can be used.")
+			err = fmt.Errorf("only one of -json, -file and -output-plugin can be used")
 			break
 		}
 		dataStore.Output, err = NewNetWriter("tcp", *logstashAddr)
 	case *jsonFile != "":
 		if *outPlugin != "" {
-			err = fmt.Errorf("Only one of -json, -file and -output-plugin can be used.")
+			err = fmt.Errorf("only one of -json, -file and -output-plugin can be used")
 			break
 		}
 		var w *jsonFileWriter
-		w, err = NewJsonFileWriter(*jsonFile)
+		w, err = newJSONFileWriter(*jsonFile)
 		if err != nil {
 			break
 		}
@@ -355,7 +351,7 @@ func main() {
 	cancel()
 
 	graceful := make(chan struct{})
-	go func() { Work.Wait(); close(graceful) }()
+	go func() { work.Wait(); close(graceful) }()
 	select {
 	case <-graceful:
 	case <-time.After(5 * time.Second):

--- a/plog/bin/plogd/server_test.go
+++ b/plog/bin/plogd/server_test.go
@@ -33,9 +33,9 @@ func (w *testWriter) WriteHeader(code int) {
 func TestServerQuery(t *testing.T) {
 	sconn := testConnect()
 	defer sconn.Close()
-	sId := hello(t, sconn, plogproto.CtxType_state, 0, "teststate")
+	sID := hello(t, sconn, plogproto.CtxType_state, 0, "teststate")
 	dataStore.testStatePing = make(chan struct{})
-	sconn.SendKeyValue(sId, "test", []byte(`"fest"`))
+	sconn.SendKeyValue(sID, "test", []byte(`"fest"`))
 	<-dataStore.testStatePing
 	dataStore.testStatePing = nil
 
@@ -56,7 +56,7 @@ func TestServerQuery(t *testing.T) {
 		t.Errorf("Expected %v, got %v, code %v", `{"value":"fest"}`, w.Buffer.String(), w.code)
 	}
 
-	goodbye(t, sconn, sId)
+	goodbye(t, sconn, sID)
 	checkLog(t, "teststate", "state", `{"test":"fest"}`)
 
 	w.Buffer.Reset()

--- a/plog/bin/plogd/session.go
+++ b/plog/bin/plogd/session.go
@@ -9,6 +9,7 @@ import (
 	"github.com/schibsted/sebase/plog/internal/pkg/plogproto"
 )
 
+// SessionOutput is the connection between session and storage.
 type SessionOutput interface {
 	OpenDict(key string) (SessionOutput, error)
 	OpenList(key string) (SessionOutput, error)
@@ -17,6 +18,7 @@ type SessionOutput interface {
 	ConfKey() string
 }
 
+// Session represents a session opened by a client.
 type Session struct {
 	store          *SessionStorage
 	SessionType    plogproto.CtxType
@@ -24,6 +26,8 @@ type Session struct {
 	StartTimestamp time.Time
 }
 
+// Close removes the session. If proper is false a dignostic might be added to
+// it first.
 func (sess *Session) Close(proper bool) {
 	sess.store.lock.Lock()
 	lastRef := false
@@ -40,6 +44,7 @@ func (sess *Session) Close(proper bool) {
 	sess.Writer.Close(proper, lastRef)
 }
 
+// SessionStorage manages sessions.
 type SessionStorage struct {
 	lock      sync.Mutex
 	CountRefs map[string]int

--- a/plog/pkg/plog/fallback.go
+++ b/plog/pkg/plog/fallback.go
@@ -1,3 +1,5 @@
+// Copyright 2020 Schibsted
+
 package plog
 
 import (
@@ -9,25 +11,28 @@ import (
 	"time"
 )
 
-// Where logs go if we can't connect to plogd. Defaults to stderr.
+// FallbackWriter is where logs go if we can't connect to plogd. Defaults to stderr.
 var FallbackWriter io.Writer = os.Stderr
 
-// Formatter for fallback writes. Can be overwritten to customize output.
-// All values are json encoded. The key is constructed recursively
-// with parent contexts prefixed, if any.
+// FallbackFormatter used for fallback writes. Can be overwritten to customize
+// output. All values are json encoded. The key is constructed recursively with
+// parent contexts prefixed, if any.
 // Setup will change the default value to FallbackFormatterSimple if it
-// detects that FallbackWriter is a tty when it's called.
+// detects that FallbackWriter is a tty when it's called. The default format
+// might change without a major package version bump, set this manually if you
+// depend on it.
 var FallbackFormatter func(key []FallbackKey, value []byte) (n int, err error) = FallbackFormatterJsonWrap
 
-// Key argument to the formatter. The slice passed to the functions has
-// one element per nested context level, followed by the key passed to
-// the log funtion.
+// FallbackKey used for key argument to the formatter. The slice passed to the
+// functions has one element per nested context level, followed by the key
+// passed to the log funtion.
 type FallbackKey struct {
 	Key   string
 	CtxId uint64
 }
 
-// Logs will be written prefixed with key and suffixed with a newline.
+// FallbackFormatterSimple creates logs thath will be written prefixed with
+// key and suffixed with a newline.
 // After FallbackFormatKey the key is joined with dots (.). The key
 // is then printed with a colon and the json encoded value after.
 func FallbackFormatterSimple(key []FallbackKey, value []byte) (n int, err error) {
@@ -47,7 +52,8 @@ func FallbackFormatterSimple(key []FallbackKey, value []byte) (n int, err error)
 	return
 }
 
-// Logs will be written as JSON objects with key, message and @timestamp fields.
+// FallbackFormatterJsonWrap creates logs that will be written as JSON objects
+// with key, message and @timestamp fields.
 // The last entry in key is logged as "type" instead.
 func FallbackFormatterJsonWrap(key []FallbackKey, value []byte) (n int, err error) {
 	var v = struct {

--- a/plog/pkg/plog/fields.go
+++ b/plog/pkg/plog/fields.go
@@ -1,3 +1,5 @@
+// Copyright 2020 Schibsted
+
 package plog
 
 import (
@@ -8,9 +10,11 @@ import (
 	"github.com/schibsted/sebase/util/pkg/slog"
 )
 
+// Fields is now just an alias for slog.KV. It's used to add key-value pairs to
+// logs.
 type Fields = slog.KV
 
-// Type TypeLogger can be used to log with preset fields. Additional
+// TypeLogger can be used to log with preset fields. Additional
 // Fields can also be added via the With method or passed together
 // with a message to LogMsg.
 //
@@ -35,7 +39,7 @@ type TypeLogger interface {
 	Panicf(format string, value ...interface{})
 }
 
-// Type Logger is an interface with functions for level based logging. Plog
+// Logger is an interface with functions for level based logging. Plog
 // context conform to this interface, as well as the WithFields return value.
 // See the Plog type for documentation about the functions in this interface.
 //

--- a/plog/pkg/plog/plog_level.go
+++ b/plog/pkg/plog/plog_level.go
@@ -1,3 +1,5 @@
+// Copyright 2020 Schibsted
+
 package plog
 
 import (
@@ -5,7 +7,7 @@ import (
 	"os"
 )
 
-// Log with a standard level key.
+// LevelPrint logs with a standard level key.
 // Only logs if level is above the threshold given to Setup (defaults to Info).
 // The value is formatted via fmt.Sprint. For JSON formatting use LogMsg.
 func (plog *Plog) LevelPrint(level Level, value ...interface{}) {
@@ -15,7 +17,7 @@ func (plog *Plog) LevelPrint(level Level, value ...interface{}) {
 	plog.Log(level.Code(), fmt.Sprint(value...))
 }
 
-// Log with a standard level key.
+// LevelPrintf logs with a standard level key.
 // Only logs if level is above the threshold given to Setup (defaults to Info).
 // The value is formatted via fmt.Sprintf. For JSON formatting use LogMsg.
 func (plog *Plog) LevelPrintf(level Level, format string, value ...interface{}) {
@@ -25,105 +27,105 @@ func (plog *Plog) LevelPrintf(level Level, format string, value ...interface{}) 
 	plog.Log(level.Code(), fmt.Sprintf(format, value...))
 }
 
-// Shorthand for plog.LevelPrint(Emergency, value).
+// Emergency is shorthand for plog.LevelPrint(Emergency, value).
 func (plog *Plog) Emergency(value ...interface{}) {
 	plog.LevelPrint(Emergency, value...)
 }
 
-// Shorthand for plog.LevelPrintf(Emergency, value).
+// Emergencyf is shorthand for plog.LevelPrintf(Emergency, value).
 func (plog *Plog) Emergencyf(format string, value ...interface{}) {
 	plog.LevelPrintf(Emergency, format, value...)
 }
 
-// Shorthand for plog.LevelPrint(Alert, value).
+// Alert is shorthand for plog.LevelPrint(Alert, value).
 func (plog *Plog) Alert(value ...interface{}) {
 	plog.LevelPrint(Alert, value...)
 }
 
-// Shorthand for plog.LevelPrintf(Alert, value).
+// Alertf is shorthand for plog.LevelPrintf(Alert, value).
 func (plog *Plog) Alertf(format string, value ...interface{}) {
 	plog.LevelPrintf(Alert, format, value...)
 }
 
-// Shorthand for plog.LevelPrint(Critical, value).
+// Critical is shorthand for plog.LevelPrint(Critical, value).
 func (plog *Plog) Critical(value ...interface{}) {
 	plog.LevelPrint(Critical, value...)
 }
 
-// Shorthand for plog.LevelPrintf(Critical, value).
+// Criticalf is shorthand for plog.LevelPrintf(Critical, value).
 func (plog *Plog) Criticalf(format string, value ...interface{}) {
 	plog.LevelPrintf(Critical, format, value...)
 }
 
-// Shorthand for plog.LevelPrint(Error, value).
+// Error is shorthand for plog.LevelPrint(Error, value).
 func (plog *Plog) Error(value ...interface{}) {
 	plog.LevelPrint(Error, value...)
 }
 
-// Shorthand for plog.LevelPrintf(Error, value).
+// Errorf is shorthand for plog.LevelPrintf(Error, value).
 func (plog *Plog) Errorf(format string, value ...interface{}) {
 	plog.LevelPrintf(Error, format, value...)
 }
 
-// Shorthand for plog.LevelPrint(Warning, value).
+// Warning is shorthand for plog.LevelPrint(Warning, value).
 func (plog *Plog) Warning(value ...interface{}) {
 	plog.LevelPrint(Warning, value...)
 }
 
-// Shorthand for plog.LevelPrintf(Warning, value).
+// Warningf is shorthand for plog.LevelPrintf(Warning, value).
 func (plog *Plog) Warningf(format string, value ...interface{}) {
 	plog.LevelPrintf(Warning, format, value...)
 }
 
-// Shorthand for plog.LevelPrint(Notice, value).
+// Notice is shorthand for plog.LevelPrint(Notice, value).
 func (plog *Plog) Notice(value ...interface{}) {
 	plog.LevelPrint(Notice, value...)
 }
 
-// Shorthand for plog.LevelPrintf(Notice, value).
+// Noticef is shorthand for plog.LevelPrintf(Notice, value).
 func (plog *Plog) Noticef(format string, value ...interface{}) {
 	plog.LevelPrintf(Notice, format, value...)
 }
 
-// Shorthand for plog.LevelPrint(Info, value).
+// Info is shorthand for plog.LevelPrint(Info, value).
 func (plog *Plog) Info(value ...interface{}) {
 	plog.LevelPrint(Info, value...)
 }
 
-// Shorthand for plog.LevelPrintf(Info, value).
+// Infof is shorthand for plog.LevelPrintf(Info, value).
 func (plog *Plog) Infof(format string, value ...interface{}) {
 	plog.LevelPrintf(Info, format, value...)
 }
 
-// Shorthand for plog.LevelPrint(Debug, value).
+// Debug is shorthand for plog.LevelPrint(Debug, value).
 func (plog *Plog) Debug(value ...interface{}) {
 	plog.LevelPrint(Debug, value...)
 }
 
-// Shorthand for plog.LevelPrintf(Debug, value).
+// Debugf is shorthand for plog.LevelPrintf(Debug, value).
 func (plog *Plog) Debugf(format string, value ...interface{}) {
 	plog.LevelPrintf(Debug, format, value...)
 }
 
-// Logs value with Critical level, then calls os.Exit(1).
+// Fatal logs value with Critical level, then calls os.Exit(1).
 func (plog *Plog) Fatal(value ...interface{}) {
 	plog.LevelPrint(Crit, value...)
 	os.Exit(1)
 }
 
-// Logs arguments with Critical level, then calls os.Exit(1).
+// Fatalf logs arguments with Critical level, then calls os.Exit(1).
 func (plog *Plog) Fatalf(format string, value ...interface{}) {
 	plog.LevelPrintf(Crit, format, value...)
 	os.Exit(1)
 }
 
-// Logs value with Critical level, then calls panic.
+// Panic logs value with Critical level, then calls panic.
 func (plog *Plog) Panic(value ...interface{}) {
 	plog.LevelPrint(Crit, value...)
 	panic(fmt.Sprint(value...))
 }
 
-// Logs arguments with Critical level, then calls panic.
+// Panicf logs arguments with Critical level, then calls panic.
 func (plog *Plog) Panicf(format string, value ...interface{}) {
 	plog.LevelPrintf(Crit, format, value...)
 	panic(fmt.Sprintf(format, value...))

--- a/plog/pkg/plogd/context.go
+++ b/plog/pkg/plogd/context.go
@@ -10,10 +10,12 @@ const (
 	contextKeyProg contextKey = iota
 )
 
+// ContextWithProg creates a new context with prog stored.
 func ContextWithProg(ctx context.Context, prog string) context.Context {
 	return context.WithValue(ctx, contextKeyProg, prog)
 }
 
+// ContextProg returns the prog stored in ctx, if any. Otherwise empty string.
 func ContextProg(ctx context.Context) string {
 	v, _ := ctx.Value(contextKeyProg).(string)
 	return v

--- a/plog/pkg/plogd/queued_writer.go
+++ b/plog/pkg/plogd/queued_writer.go
@@ -103,6 +103,6 @@ func (qw *queuedWriter) Close() error {
 	case err := <-qw.done:
 		return err
 	case <-time.After(5 * time.Second):
-		return fmt.Errorf("Timed out waiting for writer to close. Possible data loss.")
+		return fmt.Errorf("timed out waiting for writer to close, possible data loss")
 	}
 }


### PR DESCRIPTION
Identifiers can't be fixed. Also decided to keep the types of some
variables that could be inferred. I like them visible for documentation
purposes.

There was a very old go 1.4 check that I also removed.