### PR TITLE
Fixes for gcc 10 and Go 1.16.

### DIFF
--- a/core/lib/unicode.c
+++ b/core/lib/unicode.c
@@ -94,8 +94,9 @@ utf8_decode(char *dst, int *dstlen, const char *str, int slen, UConverter *utf8_
 size_t strlen_utf8(const char *str) {
 	size_t n = 0, i;
 	size_t ln = strlen(str);
-	for (i = 0 ; i < ln ; (U8_FWD_1(str, i, ln)) ) {
+	for (i = 0 ; i < ln ;  ) {
 		n++;
+		U8_FWD_1(str, i, ln);
 	}
 	return n;
 }

--- a/plog/bin/plogger/main.c
+++ b/plog/bin/plogger/main.c
@@ -9,7 +9,7 @@
 
 const char *appname;
 const char *type;
-const bool json;
+bool json;
 
 POPT_STRING("appname", NULL, &appname, "Appname to use. Defaults to the current user.");
 POPT_STRING("type", NULL, &type, "Message type to use. Defaults to log.");

--- a/plog/plugins/elasticsearch/output_writer.go
+++ b/plog/plugins/elasticsearch/output_writer.go
@@ -193,6 +193,8 @@ func (w *OutputWriter) WriteMessage(ctx context.Context, message plogd.LogMessag
 		req.Type("_doc")
 	}
 	req.Doc(w.message(ctx, &message))
+	// Force source generation here to copy all needed data.
+	req.Source()
 
 	w.bulker.Add(req)
 }

--- a/util/lib/aes.c
+++ b/util/lib/aes.c
@@ -27,8 +27,9 @@ generate_iv(unsigned char *dst, const char *src) {
 		gettimeofday(&tv, NULL);
 		snprintf((char*)dst, AES_BLOCK_SIZE, "%lx%lx", (long)tv.tv_sec, (long)tv.tv_usec);
 	} else {
-		/* This is supposed to be strncpy */
-		strncpy((char*) dst, src, AES_BLOCK_SIZE);
+		/* Could use strncpy here but newer glibc complains since it thinks it's unsafe. */
+		memset(dst, 0, AES_BLOCK_SIZE);
+		memcpy(dst, src, strnlen(src, AES_BLOCK_SIZE));
 	}
 }
 


### PR DESCRIPTION
There's still a segfault in the elasticsearch plugin. I'm currently
putting this down to a regression in Go 1.16, but since it's complicated
code it's hard to narrow down exactly.